### PR TITLE
Automatically run newly spawned threads to sync point

### DIFF
--- a/examples/failing/semantics/deadlock.gm
+++ b/examples/failing/semantics/deadlock.gm
@@ -1,0 +1,12 @@
+$t1 = spawn {
+    lock l1;
+    lock l2;
+    unlock l2;
+    unlock l1;
+};
+$t2 = spawn {
+    lock l2;
+    lock l1;
+    unlock l1;
+    unlock l2;
+};

--- a/examples/passing/semantics/lock_as_sync.gm
+++ b/examples/passing/semantics/lock_as_sync.gm
@@ -1,6 +1,6 @@
 x = 0;
 lock l1;
-t = spawn {
+$t = spawn {
   assert (x == 0);
   lock l1;
   unlock l1;

--- a/src/interpreter.hh
+++ b/src/interpreter.hh
@@ -150,6 +150,7 @@ namespace gitmem
 
     // Internal functions
     int run_threads(GlobalContext&);
+
     std::variant<ProgressStatus, TerminationStatus>
-    run_thread_to_sync(GlobalContext&, const ThreadID, std::shared_ptr<Thread>);
+    progress_thread(GlobalContext&, const ThreadID, std::shared_ptr<Thread>);
 }


### PR DESCRIPTION
This PR updates the model checker and debugger to automatically run spawned threads to sync point. This gets rid of the exponential number of schedulings when spawning threads without sync points. The model checker now also reports deadlocks separately from other errors, and the debugger prints the histories of their globals.