### PR TITLE
Feature/graphs

### DIFF
--- a/src/graph.hh
+++ b/src/graph.hh
@@ -26,6 +26,7 @@ namespace gitmem {
     struct Join;
     struct Lock;
     struct Unlock;
+    struct Pending;
 
     struct Conflict
     {
@@ -43,6 +44,7 @@ namespace gitmem {
       virtual void visitJoin(const Join*) = 0;
       virtual void visitLock(const Lock*) = 0;
       virtual void visitUnlock(const Unlock*) = 0;
+      virtual void visitPending(const Pending*) = 0;
       virtual void visit(const Node* n) { n->accept(this); }
     };
 
@@ -147,6 +149,17 @@ namespace gitmem {
       void accept(Visitor* v) const override
       {
         v->visitUnlock(this);
+      }
+    };
+
+    struct Pending : Node
+    {
+      const std::string statement;
+
+      Pending(const std::string statement): statement(statement) {}
+      void accept(Visitor* v) const override
+      {
+        v->visitPending(this);
       }
     };
   }

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -38,7 +38,7 @@ namespace graph {
   }
 
   void GraphvizPrinter::emitSyncEdge(const Node* from, const Node* to) {
-    emitEdge(from, to, "sync", "style=dashed, constraint=false");
+    emitEdge(from, to, "sync", "style=bold, constraint=false");
   }
 
   void GraphvizPrinter::emitConflict(const Node* n, const Conflict& conflict) {

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -131,5 +131,11 @@ namespace graph {
     visitProgramOrder(n->next.get());
   }
 
+  void GraphvizPrinter::visitPending(const Pending* n) {
+    assert(!n->next);
+    emitNode(n, "" + n->statement + "", "style=dashed");
+    file << "}" << std::endl;
+  }
+
 } // namespace graph
 } // namespace gitmem

--- a/src/graphviz.hh
+++ b/src/graphviz.hh
@@ -12,6 +12,7 @@ namespace gitmem {
       void visitJoin(const Join*) override;
       void visitLock(const Lock*) override;
       void visitUnlock(const Unlock*) override;
+      void visitPending(const Pending*) override;
       void visit(const Node* n) override;
 
       GraphvizPrinter(std::string filename) noexcept;

--- a/src/interpreter.hh
+++ b/src/interpreter.hh
@@ -201,6 +201,4 @@ namespace gitmem
 
     std::variant<ProgressStatus, TerminationStatus>
     progress_thread(GlobalContext &, const ThreadID, std::shared_ptr<Thread>);
-
-    std::filesystem::path build_output_path(const std::filesystem::path &, const size_t);
 }

--- a/src/mermaid.cc
+++ b/src/mermaid.cc
@@ -109,5 +109,10 @@ namespace graph {
     visitProgramOrder(n->next.get());
   }
 
+  void MermaidPrinter::visitPending(const Pending* n) {
+    assert(!n->next);
+    assert(false);
+  }
+
 } // namespace graph
 } // namespace gitmem

--- a/src/mermaid.hh
+++ b/src/mermaid.hh
@@ -12,6 +12,7 @@ namespace gitmem {
       void visitJoin(const Join*) override;
       void visitLock(const Lock*) override;
       void visitUnlock(const Unlock*) override;
+      void visitPending(const Pending*) override;
 
       MermaidPrinter(std::string filename) noexcept;
     private:

--- a/src/model_checker.cc
+++ b/src/model_checker.cc
@@ -50,6 +50,16 @@ namespace gitmem
         }
     }
 
+    /** Build an output path for the execution graph, appending an index to the
+     * filename to avoid overwriting previous graphs. */
+    std::filesystem::path build_output_path(const std::filesystem::path &output_path, const size_t idx)
+    {
+        auto parent = output_path.parent_path();
+        auto name = output_path.stem().string();
+        auto ext = output_path.extension().string();
+        return parent / (name + "_" + std::to_string(idx) + ext);
+    }
+
     /**
      * Explore all possible execution paths of the program, printing one trace
      * for each distinct final state that led to an error.


### PR DESCRIPTION
Changing the graphing:
- The debugger prints the graph at each sync point by default but can be toggled on/off
- The debugger prints to the same file
- Sync edges are bold
- The current sync point is represented in a different style pending node in the graph