### PR TITLE
Emit error node on failing assertion

### DIFF
--- a/src/graph.hh
+++ b/src/graph.hh
@@ -26,6 +26,7 @@ namespace gitmem {
     struct Join;
     struct Lock;
     struct Unlock;
+    struct AssertionFailure;
     struct Pending;
 
     struct Conflict
@@ -44,6 +45,7 @@ namespace gitmem {
       virtual void visitJoin(const Join*) = 0;
       virtual void visitLock(const Lock*) = 0;
       virtual void visitUnlock(const Unlock*) = 0;
+      virtual void visitAssertionFailure(const AssertionFailure*) = 0;
       virtual void visitPending(const Pending*) = 0;
       virtual void visit(const Node* n) { n->accept(this); }
     };
@@ -146,9 +148,22 @@ namespace gitmem {
       const std::string var;
 
       Unlock(const std::string var): var(var) {}
+
       void accept(Visitor* v) const override
       {
         v->visitUnlock(this);
+      }
+    };
+
+    struct AssertionFailure : Node
+    {
+      const std::string cond;
+
+      AssertionFailure(const std::string &cond): cond(cond) {}
+
+      void accept(Visitor* v) const override
+      {
+        v->visitAssertionFailure(this);
       }
     };
 

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -41,8 +41,12 @@ namespace graph {
     emitEdge(from, to, "sync", "style=bold, constraint=false");
   }
 
+  void GraphvizPrinter::emitFillColor(const Node* n, const std::string& color) {
+    file << "\t" << (size_t)n << "[fillcolor = " << color << "];" << std::endl;
+  }
+
   void GraphvizPrinter::emitConflict(const Node* n, const Conflict& conflict) {
-    file << "\t" << (size_t)n << "[fillcolor = red];" << std::endl;
+    emitFillColor(n, "red");
     auto [s1, s2] = conflict.sources;
     emitConflictEdge(n, s1.get());
     emitConflictEdge(n, s2.get());
@@ -127,6 +131,13 @@ namespace graph {
 
   void GraphvizPrinter::visitUnlock(const Unlock* n) {
     emitNode(n, "Unlock " + n->var);
+    emitProgramOrderEdge(n, n->next.get());
+    visitProgramOrder(n->next.get());
+  }
+
+  void GraphvizPrinter::visitAssertionFailure(const AssertionFailure* n) {
+    emitNode(n, "Assert " + n->cond);
+    emitFillColor(n, "red");
     emitProgramOrderEdge(n, n->next.get());
     visitProgramOrder(n->next.get());
   }

--- a/src/graphviz.hh
+++ b/src/graphviz.hh
@@ -12,6 +12,7 @@ namespace gitmem {
       void visitJoin(const Join*) override;
       void visitLock(const Lock*) override;
       void visitUnlock(const Unlock*) override;
+      void visitAssertionFailure(const AssertionFailure*) override;
       void visitPending(const Pending*) override;
       void visit(const Node* n) override;
 
@@ -22,6 +23,7 @@ namespace gitmem {
       void emitEdge(const Node* from, const Node* to, const std::string& label, const std::string& style = "");
       void emitProgramOrderEdge(const Node* from, const Node* to);
       void emitReadFromEdge(const Node* from, const Node* to);
+      void emitFillColor(const Node* n, const std::string& color);
       void emitConflictEdge(const Node* from, const Node* to);
       void emitSyncEdge(const Node* from, const Node* to);
       void emitConflict(const Node* n, const Conflict& conflict);

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -400,6 +400,7 @@ namespace gitmem
                 else
                 {
                     verbose << "Assertion failed: " << expr->location().view() << std::endl;
+                    thread_append_node<graph::AssertionFailure>(ctx, std::string(expr->location().view()));
                     return TerminationStatus::assertion_failure_exception;
                 }
             }


### PR DESCRIPTION
Made it so that assertion failures are visible in the execution graph as well:

![failed_assertion](https://github.com/user-attachments/assets/a66f91f8-feda-4496-9ca9-0723c4954eba)
